### PR TITLE
concrete @Embedded at multiple inheritance levels

### DIFF
--- a/src/main/java/org/example/BaseD.java
+++ b/src/main/java/org/example/BaseD.java
@@ -2,11 +2,12 @@ package org.example;
 
 
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
 
 /*
  * Created on 03/12/2024 by Paul Harrison (paul.harrison@manchester.ac.uk).
  */
-@Embeddable
+@MappedSuperclass
 public abstract class BaseD { //TODO would really like this to be abstract
   public String baseprop;
 

--- a/src/main/java/org/example/DerDB.java
+++ b/src/main/java/org/example/DerDB.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class DerDB extends BaseD {
    public DerDB(int b) {
+      super("fixed");
       this.b = b;
    }
 

--- a/src/main/java/org/example/DerDC.java
+++ b/src/main/java/org/example/DerDC.java
@@ -1,0 +1,21 @@
+package org.example;
+
+
+import jakarta.persistence.Embeddable;
+
+/*
+ * Created on 10/12/2024 by Paul Harrison (paul.harrison@manchester.ac.uk).
+ */
+@Embeddable
+public class DerDC extends DerDA {
+   String c;
+
+   public DerDC(String a, String bprop, String c) {
+      super(a, bprop);
+      this.c = c;
+   }
+
+   public DerDC() {
+
+   }
+}

--- a/src/main/java/org/example/DerOA.java
+++ b/src/main/java/org/example/DerOA.java
@@ -13,10 +13,7 @@ public class DerOA extends BaseO{
    }
 
    @Embedded
-//   @AttributeOverrides({
-//         @AttributeOverride(name="a",column = @Column(name = "da"))
-//   })
-   public BaseD derda;
+   public DerDA derda;
 
    public DerOA() {
 

--- a/src/main/java/org/example/DerOB.java
+++ b/src/main/java/org/example/DerOB.java
@@ -14,7 +14,7 @@ public class DerOB extends BaseO {
    }
 
    @Embedded
-   BaseD derdb;
+   DerDB derdb;
 
    public DerOB() {
 

--- a/src/main/java/org/example/DerOC.java
+++ b/src/main/java/org/example/DerOC.java
@@ -1,8 +1,7 @@
 package org.example;
 
 
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 
 /*
  * Created on 10/12/2024 by Paul Harrison (paul.harrison@manchester.ac.uk).
@@ -11,6 +10,9 @@ import jakarta.persistence.Entity;
 public class DerOC extends BaseO{
 
    @Embedded
+   @AttributeOverrides({
+         @AttributeOverride(name="baseprop",column = @Column(name="basep"))
+   })
    private DerDC derDC;
 
     public DerOC(DerDC derDC) {

--- a/src/main/java/org/example/DerOC.java
+++ b/src/main/java/org/example/DerOC.java
@@ -1,0 +1,27 @@
+package org.example;
+
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+
+/*
+ * Created on 10/12/2024 by Paul Harrison (paul.harrison@manchester.ac.uk).
+ */
+@Entity
+public class DerOC extends BaseO{
+
+   @Embedded
+   private DerDC derDC;
+
+    public DerOC(DerDC derDC) {
+        this.derDC = derDC;
+    }
+
+    public DerOC() {
+
+    }
+
+   public DerDC getDerDC() {
+      return derDC;
+   }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -4,9 +4,15 @@
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <class>org.example.BaseD</class>
         <class>org.example.BaseO</class>
-   <class>org.example.DerOA</class>
-   <class>org.example.DerDA</class>
-   <class>org.example.DerDB</class>
         <class>org.example.DerOB</class>
+        <class>org.example.DerOC</class>
+        <class>org.example.DerOA</class>
+        <class>org.example.DerDA</class>
+        <class>org.example.DerDB</class>
+        <class>org.example.DerDC</class>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+        <property name="hibernate.archive.autodetection" value="class, hbm"/>
+        </properties>
     </persistence-unit>
 </persistence>

--- a/src/test/java/org/example/EmbeddableTest.java
+++ b/src/test/java/org/example/EmbeddableTest.java
@@ -22,6 +22,7 @@ class EmbeddableTest {
     EntityManager em;
     DerOA deroa;
     DerOB derob;
+    DerOC deroc;
     /**
      * @throws java.lang.Exception
      */
@@ -29,8 +30,10 @@ class EmbeddableTest {
     void setUp() throws Exception {
         DerDB derba1 = new DerDB(5);
         DerDA derda1 = new DerDA("1","abase");
+        DerDC derDC = new DerDC("c","cbase","c");
         deroa = new DerOA(derda1);
         derob  = new DerOB(derba1);
+        deroc = new DerOC(derDC);
         em = setupH2Db("testing");
     }
 
@@ -40,6 +43,7 @@ class EmbeddableTest {
         em.getTransaction().begin();
         em.persist(deroa);
         em.persist(derob);
+        em.persist(deroc);
         em.getTransaction().commit();
         Integer ida = deroa.getId();
         Integer idb = derob.getId();
@@ -51,11 +55,26 @@ class EmbeddableTest {
         assertEquals("abase",deroain.derda.baseprop);
 
     }
+    @Test void testBasePropertyForC() {
+        em.getTransaction().begin();
+        em.persist(deroa);
+        em.persist(derob);
+        em.persist(deroc);
+        em.getTransaction().commit();
+        Integer idc = deroc.getId();
+        em.clear();
+        TypedQuery<DerOC> qa = em.createQuery("select o from DerOC o where o.id =:id", DerOC.class);
+        qa.setParameter("id",idc);
+        DerOC derocin = qa.getSingleResult();
+        assertEquals("cbase",derocin.getDerDC().baseprop);
+
+    }
 
     @Test void testDerivedProperty() {
         em.getTransaction().begin();
         em.persist(deroa);
         em.persist(derob);
+        em.persist(deroc);
         em.getTransaction().commit();
         Integer idb = derob.getId();
         em.clear();


### PR DESCRIPTION
Showing attempt at having a concrete @Embeddable sub-types used in 3 different places - the important feature being that one of the uses is not a base nor a leaf type with the new hierarchy from `BaseD`. This seems to cause a sort of mixed use - 

* In DerOA it is interpreted polymorphically
* In DerOB it is interpreted in a @MappedSuperclass way
* In DerOC it only the local members of DerDC are stored.

